### PR TITLE
use sd_notify crate to add support for systemd readiness notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ license = "ISC"
 aargvark = "0.7"
 defer = "0.2"
 libc = "0.2"
+sd-notify = "0.4"
 rustix = { version = "0.38", features = ["fs"] }


### PR DESCRIPTION
Hopefully this is up to your standards! This is my first time writing any Rust, so please keep that in mind. If anything appears to be inadequate, please let me know.

The only other question is whether where I've placed the readiness check is appropriate. I tried further down, but systemd never seemed to receive the signal from the code, and the service stayed stuck in the starting/waiting state.